### PR TITLE
really fixed *I think* net drop web socket reconnect

### DIFF
--- a/pickem-web/src/environments/version.ts
+++ b/pickem-web/src/environments/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = {
-    "version": "1.9.52"
+    "version": "1.9.53"
 };


### PR DESCRIPTION
Resolution for #3. The short version is the code will now handle the case where a socket event occurs, then the net connectivity drops **before** the debounce runs all the reloads of the scoreboards. 